### PR TITLE
Adjust production log level to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  config.log_level = :debug
+  config.log_level = :info
   config.log_tags = [:request_id]
 
   config.cache_store = :mem_cache_store, ENV['MEMCACHED_URL']


### PR DESCRIPTION
This PR adjust the log level of production environment to `:info` instead of `debug`.